### PR TITLE
Smarter delim chunker

### DIFF
--- a/malort/core.py
+++ b/malort/core.py
@@ -22,7 +22,7 @@ from malort.stats import recur_dict, dict_generator
 from malort.type_mappers import TypeMappers
 
 
-def analyze(path, delimiter='\n', parse_timestamps=True):
+def analyze(path, delimiter='\n', parse_timestamps=True, **kwargs):
     """
     Analyze a given directory of either .json or flat text files
     with delimited JSON to get relevant key statistics.
@@ -35,12 +35,14 @@ def analyze(path, delimiter='\n', parse_timestamps=True):
         For flat text files, the JSON blob delimiter
     parse_timestamps: boolean, default True
         If True, will attempt to regex match ISO8601 formatted parse_timestamps
+    kwargs: 
+        passed into json.loads. Here you can specify encoding, etc. 
     """
 
     stats = {}
 
     start_time = time.time()
-    for count, blob in enumerate(dict_generator(path, delimiter)):
+    for count, blob in enumerate(dict_generator(path, delimiter, **kwargs), start=1):
         recur_dict(blob, stats, parse_timestamps=parse_timestamps)
 
     elapsed = time.time() - start_time


### PR DESCRIPTION
I was having some issues reading in a large json-blob file, and noticed that we read the entire thing into memory. It's better to read it in chunks, since we are yielding them anyways. I also hit come encoding issues, so I've added `kwargs` to the `analyze` method that can be passed into the `json.loads`. Finally, I noticed it was incorrectly counting the number of blobs, and this originated in having `enumerate` start at 0. 
1. Adding smarter chunker so it can read larger files; 
2. adding `kwargs` for encoding issues
3. starting the enumerater at 1 to correctly count the number of blobs

@wrobstory for review please!
